### PR TITLE
use auth bearer

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -153,6 +153,12 @@ ClientBase.prototype._getHttp = async function (path, args, callback, headers) {
     const params = args ? "?" + qs.stringify(args) : "";
     const url = this.baseApiUri + this._setAccessToken(path + params);
 
+    if (this.accessToken) {
+      headers = Object.assign(headers || {}, {
+        Authorization: 'Bearer ' + this.accessToken
+      })
+    }
+
     const response = await axios.get(url, { headers });
 
     if (!handleHttpError(null, response, callback)) {


### PR DESCRIPTION
**Description**

experiencing this issue with oauth integration with coinbase, the package is using requesting coinbase like this
`https://api.coinbase.com/v2/accounts?&access_token=mytoken123`
when it should have been using the **Bearer Auth** scheme, i've tested my Oauth in my account Dec 5,6 and was fine but this occured recently I believe, also can't login in staging

<img width="1455" alt="Screenshot 2023-12-11 at 10 02 15 AM" src="https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/20654e63-fb08-422d-9c1c-1486da17af7c">

https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/sign-in-with-coinbase-integration#4-make-an-api-call


related logs https://app.datadoghq.com/logs?query=env%3Aprod%20status%3Aerror%20oauth%20401%20&agg_q=status%2Cservice&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_t=%2C&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&view=spans&viz=pattern&x_missing=true%2Ctrue&from_ts=1700965238005&to_ts=1702261238005&live=true

mixed with other 401 status codes, but the main issue is `invalid_token`
<img width="870" alt="Screenshot 2023-12-11 at 10 31 05 AM" src="https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/16dd300a-9f5b-4d3d-b6fb-0b91948eaab8">


<img width="1495" alt="Screenshot 2023-12-11 at 10 32 05 AM" src="https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/8648e596-5bc2-46d6-ab79-5f3366ad7313">



**Testing**

tested using rest client

https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/e620e48a-7753-4b1a-a86a-aea886c7d79f

using the app

before

https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/f2e706c9-4810-46f9-9342-5da344aea578


after

https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/3c81ab85-8846-49e5-8aa8-ce2a38740303


