### PR TITLE
use the right prototype

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -248,14 +248,6 @@ ClientBase.prototype._getAllHttp = function(opts, callback, headers) {
     }
   }
 
-  if (path && path.includes('transactions')) {
-    // adding this query param to get the nested `fees` 
-    // for the `buy` and `sells` object
-    if (!args) {
-      args = {}
-    }
-    args.expand = "all"
-  }
 
   this._getHttp(path, args, function onGet(err, result) {
     if (!handleError(err, result, callback)) {

--- a/lib/model/AccountBase.js
+++ b/lib/model/AccountBase.js
@@ -56,6 +56,15 @@ AccountBase.prototype._getAll = function(opts, callback, headers) {
     }
   }
 
+  if (path && path.includes('transactions')) {
+    // adding this query param to get the nested `fees` 
+    // for the `buy` and `sells` object
+    if (!args) {
+      args = {}
+    }
+    args.expand = "all"
+  }
+
   this.client._getHttp(path, args, function onGet(err, result) {
     if (!handleError(err, result, callback)) {
       if (result.data.length > 0) {


### PR DESCRIPTION
`AccountBase` is the prototype of `Account` which has a different `getAll` method, `ClientBase` was wrong

https://github.com/cryptotaxcalculator/coinbase-node/blob/4d9f3a86392b0c4dcd3620df6d645a76a4637ad1/lib/model/Account.js#L29-L34

https://github.com/cryptotaxcalculator/coinbase-node/blob/4d9f3a86392b0c4dcd3620df6d645a76a4637ad1/lib/model/AccountBase.js#L36-L57


the logs shown is `accounts/:id/transactions` with the `args` `{expand: "all"}`

https://github.com/cryptotaxcalculator/coinbase-node/assets/32118627/f79d50e4-57d1-44c9-8aa8-95730fcd82f0


